### PR TITLE
devops: Pass errors back to the Heroku build framework

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+set -o errexit    # always exit on error
+set -o pipefail   # don't ignore exit codes when piping output
+
 ROOT_BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3

--- a/bin/og_compile
+++ b/bin/og_compile
@@ -88,6 +88,8 @@ handle_failure() {
 }
 trap 'handle_failure' ERR
 
+crash_here_simulate_install_failure
+
 ### Initalize metadata store
 # Create the metadata store
 meta_init "$CACHE_DIR"

--- a/bin/og_compile
+++ b/bin/og_compile
@@ -88,8 +88,6 @@ handle_failure() {
 }
 trap 'handle_failure' ERR
 
-crash_here_simulate_install_failure
-
 ### Initalize metadata store
 # Create the metadata store
 meta_init "$CACHE_DIR"


### PR DESCRIPTION
Pass errors from other scripts back up to the Heroku build framework so that errors in building the app prevent the result from being deployed.

- Heroku already does this in their scripts, see the top of `bin/og_compile` for an example.
- `errexit` makes the script exit immediately if any command in the script exits with a non-zero exit code, with the same exit code.
- `pipefail` makes it so that any command in a pipe (`command1 | command2`) that returns a non-zero exit code will cause the entire script to fail; otherwise, only the exit code of the last command in the chain matters (i.e. the exit code of `command1` would be ignored, and only the exit code of `command2` would matter).


## Testing

I added a bad command to the og_compile script, tagged that version and attempted to use it to deploy to integrations-staging.

<img width="816" height="270" alt="Screenshot 2025-10-16 at 2 24 49 PM" src="https://github.com/user-attachments/assets/1e1a1801-b4af-4127-b2d9-141fd5f52b05" />


[COMPT-7080]

[COMPT-7080]: https://comptinc.atlassian.net/browse/COMPT-7080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ